### PR TITLE
Fix broken Ubuntu LAMP stack links

### DIFF
--- a/docs/platform/migrate-to-linode/how-to-migrate-from-gcp-to-linode/index.md
+++ b/docs/platform/migrate-to-linode/how-to-migrate-from-gcp-to-linode/index.md
@@ -70,7 +70,7 @@ For further details on deploying your new Linux image, follow the [Getting Start
 
 1. Once you have identified the software you would like to migrate to your Linode, you can reference our [Guides & Tutorials](/docs/) to learn how to set up your system's software on your new Linode.
 
-    For example, if your GCP instance is used to run a WordPress site, you should [install WordPress](/docs/websites/cms/install-wordpress-ubuntu-18-04/), [PHP, MySQl, and Apache](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/) or [Nginx](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) (web server) on your Linode instance.
+    For example, if your GCP instance is used to run a WordPress site, you should [install WordPress](/docs/websites/cms/install-wordpress-ubuntu-18-04/), [PHP, MySQl, and Apache](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/) or [Nginx](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) (web server) on your Linode instance.
 
 ### Create a Snapshot of your GCP Data
 

--- a/docs/platform/migrate-to-linode/migrate-a-lamp-website-to-linode/index.md
+++ b/docs/platform/migrate-to-linode/migrate-a-lamp-website-to-linode/index.md
@@ -12,7 +12,7 @@ published: 2018-07-31
 title: How to Migrate a LAMP Website to Linode
 ---
 
-This guide describes how to migrate a website running in a [LAMP](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/#what-is-a-lamp-stack) environment on another host to a new Linode. Read the [Best Practices when Migrating to Linode](/docs/platform/migrate-to-linode/best-practices-when-migrating-to-linode/) guide prior to following this guide for more information about migrating your site.
+This guide describes how to migrate a website running in a [LAMP](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/#what-is-a-lamp-stack) environment on another host to a new Linode. Read the [Best Practices when Migrating to Linode](/docs/platform/migrate-to-linode/best-practices-when-migrating-to-linode/) guide prior to following this guide for more information about migrating your site.
 
 This guide includes commands that need to be run at the command line of your current host, which may not be available if you have a shared hosting environment. Ubuntu 18.04 is used as the distribution for the new Linode deployment in this guide. If you'd like to choose another distribution, us the examples here as an approximation for the commands you'll need to run.
 

--- a/docs/platform/migrate-to-linode/migrate-a-wordpressdotcom-site-to-linode/index.md
+++ b/docs/platform/migrate-to-linode/migrate-a-wordpressdotcom-site-to-linode/index.md
@@ -16,7 +16,7 @@ external_resources:
 
 This guide describes how to export your content from WordPress.com and self-host your WordPress website on Linode. Read the [Best Practices when Migrating to Linode](/docs/platform/migrate-to-linode/best-practices-when-migrating-to-linode/) guide prior to following this guide for more information about migrating your site.
 
-Ubuntu 18.04 is used as the distribution for the new Linode deployment in this guide. If you'd like to choose another distribution, use the examples here as an approximation for the commands you'll need to run. You will also install either a [LAMP](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/) or [LEMP](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) environment on your new Linode.
+Ubuntu 18.04 is used as the distribution for the new Linode deployment in this guide. If you'd like to choose another distribution, use the examples here as an approximation for the commands you'll need to run. You will also install either a [LAMP](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/) or [LEMP](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) environment on your new Linode.
 
 {{< note >}}
 WordPress.com's export feature will export pages, posts, and comments from your site, but it will not export your themes and widgets. You will need to customize your new self-hosted WordPress site's appearance after completing your migration.

--- a/docs/platform/migrate-to-linode/migrate-from-shared-hosting-to-linode/index.md
+++ b/docs/platform/migrate-to-linode/migrate-from-shared-hosting-to-linode/index.md
@@ -90,7 +90,7 @@ The next step is to build the software environment needed for your site to funct
 *  **MySQL:** A database server.
 *  **PHP:** A software language that allows you to create and configure dynamic website content.
 
-To install a LAMP stack on Ubuntu, follow the steps in our [How to Install a LAMP Stack on Ubuntu 18.04](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/) guide.
+To install a LAMP stack on Ubuntu, follow the steps in our [How to Install a LAMP Stack on Ubuntu 18.04](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/) guide.
 
 ## Get Your Website Live
 

--- a/docs/web-servers/apache/how-to-set-up-htaccess-on-apache/index.md
+++ b/docs/web-servers/apache/how-to-set-up-htaccess-on-apache/index.md
@@ -34,7 +34,7 @@ The purpose of this guide is to show you how to set up htaccess configuration (.
 
         sudo apt-get update && sudo apt-get upgrade
 
-4.  Complete the Apache section in the [Install a Lamp Stack](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/) to install Apache on your Linode.
+4.  Complete the Apache section in the [Install a Lamp Stack](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/) to install Apache on your Linode.
 
 {{< note >}}
 Throughout this guide, replace each instance of `testuser` with your custom user account. Replace each occurrence of `example.com` with the IP address or Fully Qualified Domain Name (FQDN) of your Linode.

--- a/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
+++ b/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/index.md
@@ -4,7 +4,7 @@ author:
   email: docs@linode.com
 description: 'This tutorial outlines the steps needed to install a LAMP (Linux, Apache, MySQL, PHP) stack on Ubuntu 18.04 Long Term Support (LTS).'
 keywords: ["install lamp ubuntu 18.04", "apache install", "mysql install", "php", "ubuntu 18.04"]
-aliases: ['web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/']
+aliases: ['web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/']
 license: '[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0)'
 modified: 2019-08-27
 modified_by:

--- a/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
+++ b/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-16-04/index.md
@@ -12,7 +12,7 @@ modified_by:
 published: 2016-04-28
 title: 'How to Install a LAMP Stack on Ubuntu 16.04'
 deprecated: true
-deprecated_link: '/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/'
+deprecated_link: '/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/'
 external_resources:
  - '[Ubuntu Server Edition Homepage](http://www.ubuntu.com/server)'
  - '[Apache HTTP Server Documentation](http://httpd.apache.org/docs/2.4/)'

--- a/docs/websites/cms/install-wordpress-ubuntu-18-04/index.md
+++ b/docs/websites/cms/install-wordpress-ubuntu-18-04/index.md
@@ -37,7 +37,7 @@ Replace each instance of `example.com` in this guide with your site's domain nam
 
     The first command will output your short hostname; the second, your fully-qualified domain name (FQDN).
 
--   Configure a [LAMP](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/) or [LEMP](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) web stack.
+-   Configure a [LAMP](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/) or [LEMP](/docs/web-servers/lemp/how-to-install-a-lemp-server-on-ubuntu-18-04/) web stack.
 
 -   If you're running NGINX, edit the `location /` block of your configuration to set `index.php` as an index for the site:
 

--- a/docs/websites/cms/install-wordpress-using-wp-cli-on-ubuntu-18-04/index.md
+++ b/docs/websites/cms/install-wordpress-using-wp-cli-on-ubuntu-18-04/index.md
@@ -32,7 +32,7 @@ This guide is written for Ubuntu 18.04. Before moving ahead, make sure you have 
 
 * [Getting Started with Linode](/docs/getting-started/)
 * [Securing your Server](/docs/security/securing-your-server/)
-* [How to Install a LAMP Stack on Ubuntu 18.04](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04/)
+* [How to Install a LAMP Stack on Ubuntu 18.04](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04/)
 
 {{< note >}}
 This guide is written for a non-root user. Commands that require elevated privileges are prefixed with `sudo`. If you're not familiar with the `sudo` command, you can check our [Users and Groups](/docs/tools-reference/linux-users-and-groups/) guide.

--- a/docs/websites/wikis/install-mediawiki-on-ubuntu-1804/index.md
+++ b/docs/websites/wikis/install-mediawiki-on-ubuntu-1804/index.md
@@ -19,7 +19,7 @@ external_resources:
 
 MediaWiki is a popular, free wiki software package. It's the same software Wikipedia uses. It is fully dynamic and runs on a LAMP stack, taking advantage of the PHP language and the MySQL database backend. With easy installation and configuration, MediaWiki is a good solution when you need a familiar, full-featured, dynamic wiki engine.
 
-This guide assumes that you already have a working [LAMP stack](/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04) running on Ubuntu. Your web accessible `DocumentRoot` should be located in `/var/www/html/example.com/public_html/`. You should be connected to your server via SSH and logged in as root.
+This guide assumes that you already have a working [LAMP stack](/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04) running on Ubuntu. Your web accessible `DocumentRoot` should be located in `/var/www/html/example.com/public_html/`. You should be connected to your server via SSH and logged in as root.
 
 ## Download and Unpack MediaWiki
 


### PR DESCRIPTION
Replace
'/docs/web-servers/lamp/install-lamp-stack-on-ubuntu-18-04'
with
'/docs/web-servers/lamp/how-to-install-a-lamp-stack-on-ubuntu-18-04'